### PR TITLE
refactor to remove extra buffer; add placeholder for cases

### DIFF
--- a/include/btchip_context.h
+++ b/include/btchip_context.h
@@ -328,6 +328,6 @@ void btchip_context_init(void);
 #define ETP_AMOUNT btchip_context_D.inputValue // unsigned char[8]
 #define ETP_DECIMALS btchip_context_D.nExpiryHeight[0] // unsigned char
 #define ETP_LENGTH btchip_context_D.nExpiryHeight[1] // unsigned char
-#define ETP_TMP btchip_context_D.nExpiryHeight[2] // unsigned char
+// #define ETP_TMP btchip_context_D.nExpiryHeight[2] // unsigned char
 
 #endif


### PR DESCRIPTION
I think we can remove `ETP_BUFF` if we read the addresses directly in the other two files too. I've added placeholders for all the cases but we can choose not to support them for the first official version when we request PR to LedgerHQ. 